### PR TITLE
fix: API 31/32 玻璃折射的首帧与失败兜底，修开关旋钮按压态消失

### DIFF
--- a/app/src/androidTest/java/com/tyust/course/ui/system/glass/GlassLensRendererTest.kt
+++ b/app/src/androidTest/java/com/tyust/course/ui/system/glass/GlassLensRendererTest.kt
@@ -264,6 +264,107 @@ class GlassLensRendererTest {
     }
 
     @Test
+    fun restPathIsExactlyVibrancyOfSource() {
+        // 静止态（lensAmount = 0）着色器走短路：输出应当**逐点等于**
+        // setSaturation(vibrancy) 作用在底图同点上，位移与色散都不参与。
+        //
+        // 这一条是探针脚本 cmp.py 的核心断言，此前只在设备上手工跑过，而它的
+        // 「预测 vs 实测」曾报出约 6% 的亮度差（文档第 9 节）。把它钉成用例：
+        // 若差异真在着色器/采样/回读这一侧，这里会直接红；若这里绿，那 6% 就
+        // 只可能出在截图侧（合成的 tint/highlight）或对比用的底图不是同一帧。
+        //
+        // 采样点必须落在纹素中心才谈得上「逐点相等」：toSrc 给出
+        // (srcLeft + i + 0.5) / srcWidth，所以 left/top 取**整数**时正中纹素中心，
+        // GL_LINEAR 不混邻居。真实调用方传的是浮点窗口坐标（元素在动），那属于
+        // 另一回事，不在本用例范围内。
+        val srcW = 320
+        val srcH = 200
+        val ew = 128
+        val eh = 96
+        val left = 16
+        val top = 12
+        val sat = 1.28f
+        val renderer = RendererPair()
+        try {
+            // 彩色内容：纯灰的话 setSaturation 是恒等变换，测不出饱和度是否真的施加了
+            val src = Bitmap.createBitmap(srcW, srcH, Bitmap.Config.ARGB_8888)
+            for (y in 0 until srcH) {
+                for (x in 0 until srcW) {
+                    src.setPixel(
+                        x, y,
+                        Color.rgb((x * 7 + y * 3) % 256, (x * 3 + y * 11) % 256, (x * 13 + y * 5) % 256)
+                    )
+                }
+            }
+            renderer.uploadSource(src, version = 1)
+            renderer.submit(
+                GlassLensParams(
+                    widthPx = ew,
+                    heightPx = eh,
+                    srcLeftPx = left.toFloat(),
+                    srcTopPx = top.toFloat(),
+                    // 半径 0：整块都在形状内，sd < 0 处处成立
+                    cornerRadiusPx = 0f,
+                    thicknessPx = 30f,
+                    // 静止：位移为 0，走 applyVibrancy 短路
+                    lensAmountPx = 0f,
+                    dispersion = 1f,
+                    depthEffect = 0f,
+                    vibrancy = sat
+                )
+            )
+            val out = awaitFrame(renderer)
+            assertFalse("renderer failed", renderer.failed)
+            assertNotNull("no frame produced", out)
+            out!!
+
+            var worst = 0f
+            var worstAt = ""
+            var sumAbs = 0.0
+            var n = 0
+            for (j in 0 until eh) {
+                for (i in 0 until ew) {
+                    val s = src.getPixel(left + i, top + j)
+                    val o = out.getPixel(i, j)
+                    // 与着色器 applyVibrancy 同式：BT.709 luma 与原色之间 mix，末端 clamp
+                    val l = 0.213f * Color.red(s) + 0.715f * Color.green(s) + 0.072f * Color.blue(s)
+                    for (ch in 0..2) {
+                        val c = when (ch) {
+                            0 -> Color.red(s)
+                            1 -> Color.green(s)
+                            else -> Color.blue(s)
+                        }
+                        val expect = (l + (c - l) * sat).coerceIn(0f, 255f)
+                        val actual = when (ch) {
+                            0 -> Color.red(o)
+                            1 -> Color.green(o)
+                            else -> Color.blue(o)
+                        }
+                        val d = abs(actual - expect)
+                        sumAbs += d
+                        n++
+                        if (d > worst) {
+                            worst = d
+                            worstAt = "($i,$j) ch$ch expect=$expect actual=$actual"
+                        }
+                    }
+                    assertTrue("alpha must be opaque inside the shape at ($i,$j)", Color.alpha(o) == 255)
+                }
+            }
+            val mean = sumAbs / n
+            // 容差 2/255：留给 8 位量化与 GPU 浮点精度，堵不住 6% 级（约 15/255）的偏差
+            assertTrue(
+                "rest path deviates from setSaturation($sat): mean=$mean worst=$worst at $worstAt",
+                worst <= 2
+            )
+
+            src.recycle()
+        } finally {
+            renderer.release()
+        }
+    }
+
+    @Test
     fun multipleRenderersShareOneContextAndAllProduceFrames() {
         // 玻璃元素有十来处。每处一个 EGL 上下文是走不通的（建一个要 10–50ms，
         // 还各占一条线程），所以上下文与 program 是进程级共享的（GlassLensEngine）。

--- a/app/src/androidTest/java/com/tyust/course/ui/system/glass/GlassLensRendererTest.kt
+++ b/app/src/androidTest/java/com/tyust/course/ui/system/glass/GlassLensRendererTest.kt
@@ -218,6 +218,52 @@ class GlassLensRendererTest {
     }
 
     @Test
+    fun reUploadSameSizeUpdatesOutput() {
+        // 同尺寸、版本号变化的重传走 texSubImage2D 子区域更新：滚动限频期间
+        // 每 100ms 一次都是这条路。若重传被短路、或子区域更新写错了位置/内容，
+        // 折射会永远停在第一张底图上（屏幕上是「滚了半天胶囊里还是老画面」）。
+        val renderer = RendererPair()
+        try {
+            val src = stripes(1002, 168)
+            renderer.uploadSource(src, version = 1)
+            renderer.submit(params(195, 156, left = 11f, top = 6f))
+            val first = awaitFrame(renderer)
+            assertNotNull("no first frame", first)
+            val firstCopy = first!!.copy(Bitmap.Config.ARGB_8888, false)
+
+            // 同尺寸、相位偏移 5px（20px 周期的 1/4）：每个采样点的内容都变
+            val src2 = Bitmap.createBitmap(1002, 168, Bitmap.Config.ARGB_8888)
+            for (y in 0 until 168) {
+                for (x in 0 until 1002) {
+                    val on = (((x + 5) / 10) % 2) == 0
+                    src2.setPixel(x, y, if (on) Color.rgb(30, 30, 30) else Color.rgb(225, 225, 225))
+                }
+            }
+            renderer.uploadSource(src2, version = 2)
+            renderer.submit(params(195, 156, left = 11f, top = 6f))
+
+            val deadline = System.currentTimeMillis() + 5000
+            var changed = false
+            while (System.currentTimeMillis() < deadline) {
+                val now = renderer.latest
+                if (now != null && !now.sameAs(firstCopy)) {
+                    changed = true
+                    break
+                }
+                Thread.sleep(16)
+            }
+            assertFalse("renderer failed", renderer.failed)
+            assertTrue("same-size re-upload did not change the output", changed)
+
+            firstCopy.recycle()
+            src.recycle()
+            src2.recycle()
+        } finally {
+            renderer.release()
+        }
+    }
+
+    @Test
     fun multipleRenderersShareOneContextAndAllProduceFrames() {
         // 玻璃元素有十来处。每处一个 EGL 上下文是走不通的（建一个要 10–50ms，
         // 还各占一条线程），所以上下文与 program 是进程级共享的（GlassLensEngine）。

--- a/app/src/main/java/com/tyust/course/ui/system/LiquidComponents.kt
+++ b/app/src/main/java/com/tyust/course/ui/system/LiquidComponents.kt
@@ -370,6 +370,26 @@ fun LiquidButton(
     }
 }
 
+/**
+ * 开关折射底图里轨道的横向缩放。与 33+ 按满那一档一致。
+ *
+ * 横向不需要留环境边：旋钮半宽 52.5px 本来就在缩后轨道半宽 63px 以内
+ * （@420dpi），两条路都没有横向带。
+ */
+private const val SWITCH_LENS_TRACK_SCALE_X = 0.75f
+
+/**
+ * 开关折射底图里轨道的**纵向**缩放。
+ *
+ * **不是** 33+ 按满那一档的 0.75，理由见 `switchLensAnchor` 处的长注释：烤 0.75
+ * 时旋钮只探出轨道 3.9px，而斜坡宽 13.1px，斜坡里几乎全是轨道绿 —— 按下去旋钮
+ * 整块消失（用户报过，API32/API35 逐像素对比确认）。
+ *
+ * 0.4 让旋钮上下各探出 16.8px（> 13.1px 斜坡），与 API35 目测的 16/18px 环境带
+ * 对得上。改这个数之前先按 `docs/glass-lens-api32.md` 的方法两台设备对拍。
+ */
+private const val SWITCH_LENS_TRACK_SCALE_Y = 0.4f
+
 @Composable
 fun LiquidSwitch(
     checked: Boolean,
@@ -494,9 +514,29 @@ fun LiquidSwitch(
     // DrawScope 里，默认绕自身中心。绕锚点中心缩会让旋钮在 checked 那一端探出
     // 轨道右缘 6dp。
     //
-    // 烤的是**按满**那一档（0.75），不是当前帧的值：静止态折射为 0、表面是不透明
-    // 实色，底图根本看不见；只有按满时它才可见。中途那一两百毫秒里折射强度与表面
-    // 透明度都在同步变化，差异被自己盖住。
+    // ## scaleY 烤 0.4，不是按满那一档的 0.75
+    //
+    // 33+ 的轨道缩放是**动画**：`scaleY = lerp(0f, 0.75f, progress)`（上面
+    // scaledTrackBackdrop）。底图只能烤一个固定值，而烤 0.75 实测是错的 ——
+    // 用户报「按下旋钮消失」，两台设备同页同控件（1080x2400 @420dpi，开关都在
+    // x817-984）逐像素对比：
+    //
+    //   API35（33+ 真 AGSL）按压中，旋钮上下各有一条**环境色**带：
+    //     y1750-1765(16px) 与 y1820-1837(18px)，值约 (149,128,181) 淡紫 = 壁纸
+    //   API32（本路径，曾烤 0.75）同一时刻：
+    //     旋钮内部**一条带都没有**，整块 (52,199,89) 纯轨道绿 —— 旋钮消失
+    //
+    // 几何算得通：斜坡宽 5dp = 13.1px，旋钮半高 31.5px。要让斜坡整条都采到轨道
+    // 外面，缩后轨道半高必须 ≤ 31.5 - 13.1 = 18.4px，即 scaleY ≤ 0.50。
+    // 烤 0.75 时缩后半高 27.6px，旋钮只探出 3.9px —— 斜坡里绝大部分仍是绿，
+    // 那 3.9px 被稀释掉，屏幕上就是纯绿。烤 0.4 时探出 16.8px，与 API35 目测的
+    // 16/18px 带宽对得上。
+    //
+    // 曾经这里的注释说「中途那一两百毫秒差异被自己盖住」—— 那句是错的，上面的
+    // 逐像素对比就是反例：用户看见的正是按压途中那一档。
+    //
+    // scaleX 仍是 0.75：横向旋钮半宽 52.5px 本来就在缩后轨道半宽 63px 以内，
+    // 两条路都没有横向环境带，这是设计如此（见 GlassLens 的中心轴注记）。
     // 显式命名：DrawScope 里的 `density` 是 Float 成员，写 `density` 靠的是重载
     // 解析恰好挑中外层这个 Density。改个名就不必依赖那个巧合。
     val switchLensDensity = density
@@ -517,8 +557,8 @@ fun LiquidSwitch(
             val thumbCenterX =
                 (if (checked) padding + dragWidth else padding) + 40.dp.toPx() / 2f
             scale(
-                scaleX = 0.75f,
-                scaleY = 0.75f,
+                scaleX = SWITCH_LENS_TRACK_SCALE_X,
+                scaleY = SWITCH_LENS_TRACK_SCALE_Y,
                 pivot = Offset(thumbCenterX, size.height / 2f)
             ) {
                 with(trackBackdrop) { drawBackdrop(switchLensDensity, coords, null) }

--- a/app/src/main/java/com/tyust/course/ui/system/glass/GlassLens.kt
+++ b/app/src/main/java/com/tyust/course/ui/system/glass/GlassLens.kt
@@ -1,7 +1,10 @@
 package com.tyust.course.ui.system.glass
 
 import android.graphics.Bitmap
+import android.graphics.ColorMatrix
+import android.graphics.ColorMatrixColorFilter
 import android.graphics.Paint
+import android.graphics.Path
 import android.graphics.Picture
 import android.os.Build
 import androidx.compose.runtime.Composable
@@ -14,6 +17,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.withFrameNanos
+import com.tyust.course.BuildConfig
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.CanvasHolder
@@ -111,8 +116,25 @@ class GlassLensAnchor internal constructor(
     private var uploadedVersion = -1
     private var captureFailed = false
 
+    /**
+     * 「首拍完成 → 首帧渲出」之间的兜底底图（capture 产物本体，ARGB_8888）。
+     *
+     * 折射帧是异步渲的（提交 → GL 线程 → onFrameReady → 重绘），而调用方的
+     * `onDrawBackdrop` 在锚点非 null 时已经把背景绘制让给了折射 —— 中间这一两帧
+     * 元素会整块无背景。这张位图填那个洞：还没有渲出帧的任何时刻，元素直接画
+     * 底图上自己那块（[GlassLensNode] 的 drawFallback）。
+     *
+     * capture 产物本来上传完就弃，保留引用零额外采集成本；首帧画出
+     * （[onFrameDrawn]）即丢弃，稳态不占内存。
+     */
+    internal var fallbackBitmap: Bitmap? = null
+        private set
+
+    private var hasRenderedFrame = false
+
     internal fun onPositioned(coords: LayoutCoordinates) {
         coordinates = coords
+        unattachedDraws = 0
         val s = IntSize(coords.size.width, coords.size.height)
         if (s != sizePx) sizePx = s
     }
@@ -124,15 +146,40 @@ class GlassLensAnchor internal constructor(
 
     private var warnedUnanchored = false
 
-    /** 只吼一次，别把 logcat 刷满。 */
+    /** 连续多少次 draw 仍然没有 coordinates。挂上即清零。 */
+    private var unattachedDraws = 0
+
+    /**
+     * draw 期发现锚点还没有 coordinates。
+     *
+     * 立刻吼是误报：分段控件的锚点经 `SideEffect` + state 绕一帧才挂上
+     * （LiquidSelectionComponents 的 segLensAnchor），首个 draw 必然读不到
+     * coordinates —— 实测每个分段控件都会在首帧吼一次。数到第 3 次仍未挂上
+     * 才算真的没挂。组合期自检（等 2 帧）与这里互为冗余，谁先到谁报。
+     */
+    internal fun noteDrawUnanchored() {
+        unattachedDraws++
+        if (unattachedDraws >= 3) warnUnanchored()
+    }
+
+    /**
+     * 只吼一次，别把 logcat 刷满。已经挂上的锚点不吼（组合期自检可能在
+     * `glassLensAnchor` 尚未布局完成时先来问一次）。
+     *
+     * debug 构建用 `Log.wtf` 让 Logcat 高亮：这是调用方的编码错误，而它的
+     * 后果（整块元素无背景）属于"看截图猜不出来"的那一级。
+     */
     internal fun warnUnanchored() {
-        if (warnedUnanchored) return
+        if (warnedUnanchored || coordinates != null) return
         warnedUnanchored = true
-        android.util.Log.e(
-            TAG,
+        val msg =
             "lens region '$tag' was never attached with Modifier.glassLensAnchor — " +
                 "elements using it will have no background at all"
-        )
+        if (BuildConfig.DEBUG) {
+            android.util.Log.wtf(TAG, msg)
+        } else {
+            android.util.Log.e(TAG, msg)
+        }
     }
 
     /** 确保底图已上传。返回底图尺寸，未就绪返回 null。 */
@@ -156,12 +203,34 @@ class GlassLensAnchor internal constructor(
         if (bitmap == null) {
             if (!captureFailed) android.util.Log.w(TAG, "backdrop capture returned null")
             captureFailed = true
+            // 捕获失败必须走 snapshot 失败传播（与 GL 失败同一条路）：
+            // rememberGlassLensAnchor 读到 source.failed 后收回锚点，站点重组
+            // 切回 blur 兜底。曾经这里只 latch 一个普通 Boolean —— 锚点保持
+            // 非 null、调用方继续让掉背景绘制，元素从此**永久空白**，
+            // 正是第 8 节"失败必须让组合期读到"要防的那种事故。
+            source.failCapture()
+            clearFallback()
             return null
         }
         source.uploadSource(bitmap, version)
         uploadedKey = key
         uploadedVersion = version
+        if (!hasRenderedFrame) fallbackBitmap = bitmap
         return size
+    }
+
+    /** 首帧折射结果已画出：兜底位图功成身退。 */
+    internal fun onFrameDrawn() {
+        if (hasRenderedFrame) return
+        hasRenderedFrame = true
+        // 只置 null 不 recycle：区域内其他元素此刻可能还在画同一张位图，
+        // recycle 会 use-after-recycle。位图交给 GC，稳态内存归零。
+        fallbackBitmap = null
+    }
+
+    /** 丢弃兜底位图引用（锚点离开组合 / 捕获失败时）。同样不 recycle，理由同上。 */
+    internal fun clearFallback() {
+        fallbackBitmap = null
     }
 
     /**
@@ -314,6 +383,16 @@ fun rememberGlassLensAnchor(
     // lambda 每次组合都是新实例，但 anchor 要保持同一个（它持有 GL 资源），
     // 所以逐次刷新引用而不是把 lambda 放进 remember 的 key
     anchor.drawSource = drawSource
+    if (BuildConfig.DEBUG) {
+        // 组合期自检：锚点忘了挂 Modifier.glassLensAnchor 是编码错误，但它的
+        // 后果（元素无背景）只在区域内首个元素 draw 时才暴露；区域内暂时没有
+        // 折射元素时（如弹窗还没开过）就一直静默。等两帧（布局跑完）主动查一次。
+        // 33+ 在函数开头就早退了，这里零开销。
+        LaunchedEffect(anchor) {
+            repeat(2) { withFrameNanos { } }
+            anchor.warnUnanchored()
+        }
+    }
     // 换壁纸必须重拍，**这一条建在锚点里，不交给调用方**。
     //
     // 壁纸是每一张底图的最底层：没有哪个区域的底图能在壁纸变了之后还是对的。
@@ -345,7 +424,10 @@ fun rememberGlassLensAnchor(
         }
     }
     DisposableEffect(anchor) {
-        onDispose { anchor.source.release() }
+        onDispose {
+            anchor.source.release()
+            anchor.clearFallback()
+        }
     }
     // 底图彻底失败（GL 挂了、快照拿不到）时把锚点收回去，让站点整体退回 blur 路径。
     // 不收的话站点会保持折射路径，而折射路径把背景绘制让给了折射本身 ——
@@ -589,6 +671,16 @@ private class GlassLensNode(
     private var windowOffset = Offset.Zero
     private val paint = Paint().apply { isFilterBitmap = true }
 
+    // 兜底路径的绘制用具：饱和度滤镜复现着色器的 applyVibrancy
+    // （ColorMatrix.setSaturation 与 mix(luminance, rgb, sat) 同式），
+    // 圆角轮廓用 Path 裁剪。
+    private var fallbackPaint: Paint? = null
+    private var fallbackSaturation = Float.NaN
+    private val fallbackSrc = android.graphics.Rect()
+    private val fallbackClip = Path()
+
+    /** 元素完整轮廓的 dst 框（圆角按它构造，与被裁到的可见 dstRect 区分开）。 */
+    private val fallbackFullDst = android.graphics.RectF()
 
     // 逐实例可变对象，避免多个指示器共享时互相踩
     private val srcRect = android.graphics.Rect()
@@ -617,43 +709,24 @@ private class GlassLensNode(
         // 锚点没被 Modifier.glassLensAnchor 挂到任何节点上 —— 这是调用方的编码错误，
         // 而它的后果很隐蔽：折射一个像素都不画，同时调用方的 onDrawBackdrop 已经把
         // 背景绘制让给了折射，于是整块元素**没有背景**（弹窗上实拍到过一次：卡片
-        // 完全消失，只剩文字和按钮浮在页面上）。所以这里必须吵。
+        // 完全消失，只剩文字和按钮浮在页面上）。所以必须吵 —— 但要去抖（见
+        // noteDrawUnanchored：SideEffect 绕一帧挂锚点的控件首帧必然在这里误报）。
         if (anchor.coordinates == null) {
-            anchor.warnUnanchored()
+            anchor.noteDrawUnanchored()
             return
         }
         anchor.ensureSource() ?: return
         val anchorCoords = anchor.coordinates ?: return
         val renderer = target
-        if (renderer.failed) return
 
         val origin = anchorCoords.positionInWindow()
         val left = windowOffset.x - origin.x
         val top = windowOffset.y - origin.y
 
-        // 先画上一帧的结果，再提交这一帧：在 draw() 里等 GPU 会钉住 UI 线程
-        // 尺寸不一致时**拉伸**而不是丢弃：上一帧的尺寸在布局收敛或动画中经常
-        // 与当前差几像素，严格相等的判断会把「差一帧」放大成「永远不画」。
-        // 几像素的缩放看不出来，不画则是致命的。
+        // 先画上一帧的结果，再提交这一帧：在 draw() 里等 GPU 会钉住 UI 线程。
         // 与库那层 layerBlock 同一份形变：缩放与平移都要跟上，
         // 否则库画的 surface/highlight 与折射会错开（见 GlassLensTransform）。
         val t = scale?.compute(size.width, size.height) ?: GlassLensTransform.Identity
-
-        renderer.latest?.let { frame ->
-            if (!frame.isRecycled) {
-                // 不再翻转：glReadPixels 的自下而上与 copyPixelsFromBuffer 的
-                // 自上而下已互相抵消（见 GlassLensRenderer）。多翻一次会上下镜像。
-                srcRect.set(0, 0, frame.width, frame.height)
-                // 拉伸而非重渲染：库也是先按原尺寸跑完着色器、再由 graphicsLayer
-                // 整层缩放，两者等价。这样 GL 侧的 FBO 尺寸也不必随动画每帧重建。
-                val dw = w * t.scaleX
-                val dh = h * t.scaleY
-                val dx = (w - dw) / 2f + t.translationX
-                val dy = (h - dh) / 2f + t.translationY
-                dstRect.set(dx, dy, dx + dw, dy + dh)
-                drawContext.canvas.nativeCanvas.drawBitmap(frame, srcRect, dstRect, paint)
-            }
-        }
 
         val halfMin = minOf(w, h) / 2f
 
@@ -668,6 +741,40 @@ private class GlassLensNode(
         // 这类"标称 vs 实测"的错配已经害过两次（另一次是斜坡宽度），
         // 所以这里的原则是：**光学参数一律按实测尺寸夹一遍**。
         val radius = optics.cornerRadiusPx.coerceIn(0f, halfMin)
+
+        val frame = renderer.latest
+        if (frame != null && !frame.isRecycled) {
+            // 尺寸不一致时**拉伸**而不是丢弃：上一帧的尺寸在布局收敛或动画中经常
+            // 与当前差几像素，严格相等的判断会把「差一帧」放大成「永远不画」。
+            // 几像素的缩放看不出来，不画则是致命的。
+            // 不再翻转：glReadPixels 的自下而上与 copyPixelsFromBuffer 的
+            // 自上而下已互相抵消（见 GlassLensRenderer）。多翻一次会上下镜像。
+            srcRect.set(0, 0, frame.width, frame.height)
+            // 拉伸而非重渲染：库也是先按原尺寸跑完着色器、再由 graphicsLayer
+            // 整层缩放，两者等价。这样 GL 侧的 FBO 尺寸也不必随动画每帧重建。
+            val dw = w * t.scaleX
+            val dh = h * t.scaleY
+            val dx = (w - dw) / 2f + t.translationX
+            val dy = (h - dh) / 2f + t.translationY
+            dstRect.set(dx, dy, dx + dw, dy + dh)
+            drawContext.canvas.nativeCanvas.drawBitmap(frame, srcRect, dstRect, paint)
+            anchor.onFrameDrawn()
+        } else {
+            // 首帧间隙（提交 → GL 线程 → onFrameReady → 重绘，约一帧）：画兜底
+            // 底图上自己那块。调用方的 onDrawBackdrop 在锚点非 null 时已把背景
+            // 绘制让给了折射，这一帧不画东西就是整块空白 —— App 冷启动的底栏上
+            // 肉眼可见。已知接受的残余：兜底位图在首帧渲出后即被丢弃，此后**新
+            // 出现**的元素（如开弹窗）仍有 1 帧空白，有入场淡入遮掩，不值得为它
+            // 常驻一张全屏位图。
+            drawFallback(left, top, w, h, radius, t, optics.vibrancy)
+        }
+
+        // 元素级失败（如这台设备的 FBO 建不起来）：上面的 stale latest / 兜底已
+        // 保证有东西可看，这里只是不再提交新帧 —— 冻结在最后一帧好过永远空白。
+        // 曾经这行是放在画 latest **之前**的提前 return，而 target 的 ownFailed
+        // 不是 snapshot state、组合期读不到：失败后既不切回 blur 路径，也一个
+        // 像素都不画，直到元素重组（持久元素如底栏则直到重启）。
+        if (renderer.failed) return
 
         // 斜坡上限同样按实测短边施加：斜坡宽到吃掉整个形状时，折射会退化成一个
         // 空心发光环而不是玻璃（实测占半短边 0.6 就是这样）。
@@ -693,5 +800,80 @@ private class GlassLensNode(
                 vibrancy = optics.vibrancy
             )
         )
+    }
+
+    /**
+     * 首帧间隙 / 元素级失败后的兜底：直接画底图上自己那块区域。
+     *
+     * 与着色器的差异只有两处，都是刻意的近似：
+     * - 没有折射位移与色散（那正是还没渲出来的东西）；
+     * - 饱和度用 `ColorMatrix.setSaturation(vibrancy)` 复现 applyVibrancy。
+     *
+     * 圆角用与着色器同一个（已按实测尺寸夹取的）radius 裁剪，且跟着形变缩放
+     * （latest 的画法里圆角同样被 dstRect 缩放）；底图边界外的份额按比例收缩
+     * **dst**（避免 drawBitmap 把可见子区域拉伸到整个目标框），但**不缩半径** ——
+     * 圆角按元素完整轮廓走，见下面 fallbackFullDst 处的注释。
+     */
+    private fun DrawScope.drawFallback(
+        left: Float,
+        top: Float,
+        w: Int,
+        h: Int,
+        radius: Float,
+        t: GlassLensTransform,
+        vibrancy: Float
+    ) {
+        val bmp = anchor.fallbackBitmap ?: return
+        if (bmp.isRecycled) return
+        val bw = bmp.width.toFloat()
+        val bh = bmp.height.toFloat()
+        if (bw < 1f || bh < 1f) return
+
+        // 元素在底图上的窗口（与 u_srcOrigin 同一坐标系），夹到底图边界内。
+        // src 用整型 Rect（Canvas 只有 (Rect, RectF) 这个重载）：亚像素损失对
+        // 一两帧的兜底画面无所谓，dst 的份额按取整后的值算，保证映射不偏。
+        val sx0 = left.coerceIn(0f, bw).toInt()
+        val sy0 = top.coerceIn(0f, bh).toInt()
+        val sx1 = (left + w).coerceIn(0f, bw).toInt().coerceAtLeast(sx0 + 1)
+        val sy1 = (top + h).coerceIn(0f, bh).toInt().coerceAtLeast(sy0 + 1)
+        if (sx1 - sx0 < 1 || sy1 - sy0 < 1) return
+
+        val p = fallbackPaint ?: Paint(Paint.FILTER_BITMAP_FLAG).also { fallbackPaint = it }
+        if (fallbackSaturation != vibrancy) {
+            fallbackSaturation = vibrancy
+            p.colorFilter = ColorMatrixColorFilter(
+                ColorMatrix().apply { setSaturation(vibrancy) }
+            )
+        }
+
+        val dw = w * t.scaleX
+        val dh = h * t.scaleY
+        val dx = (w - dw) / 2f + t.translationX
+        val dy = (h - dh) / 2f + t.translationY
+        // 被底图边界裁掉的份额 → dst 按比例收缩（正常情况 u0v0=0、u1v1=1）
+        val u0 = (sx0 - left) / w
+        val v0 = (sy0 - top) / h
+        val u1 = (sx1 - left) / w
+        val v1 = (sy1 - top) / h
+        fallbackSrc.set(sx0, sy0, sx1, sy1)
+        dstRect.set(dx + dw * u0, dy + dh * v0, dx + dw * u1, dy + dh * v1)
+
+        val canvas = drawContext.canvas.nativeCanvas
+        val save = canvas.save()
+        // 圆角按元素**完整**轮廓构造，半径只随形变缩放 —— 圆角是形状的属性，不是
+        // 「可见了多少」的属性。曾经这里把半径乘了可见比例 (u1-u0)，于是被底图
+        // 边界裁掉一半的元素会得到半圆角。与可见区域求交不必再 clip 一次：
+        // 下面的 drawBitmap 本就只覆盖 dstRect。
+        fallbackFullDst.set(dx, dy, dx + dw, dy + dh)
+        fallbackClip.reset()
+        fallbackClip.addRoundRect(
+            fallbackFullDst,
+            radius * t.scaleX,
+            radius * t.scaleY,
+            Path.Direction.CW
+        )
+        canvas.clipPath(fallbackClip)
+        canvas.drawBitmap(bmp, fallbackSrc, dstRect, p)
+        canvas.restoreToCount(save)
     }
 }

--- a/app/src/main/java/com/tyust/course/ui/system/glass/GlassLensEngine.kt
+++ b/app/src/main/java/com/tyust/course/ui/system/glass/GlassLensEngine.kt
@@ -182,9 +182,4 @@ internal object GlassLensEngine {
         uniformLocations.getOrPut(name) {
             GLES20.glGetUniformLocation(program, name)
         }
-
-    /** 仅供测试：让下一次 [ensureReady] 重新建上下文。 */
-    internal fun resetForTest() {
-        uniformLocations.clear()
-    }
 }

--- a/app/src/main/java/com/tyust/course/ui/system/glass/GlassLensRenderer.kt
+++ b/app/src/main/java/com/tyust/course/ui/system/glass/GlassLensRenderer.kt
@@ -106,10 +106,17 @@ internal class GlassLensSource {
                 }
                 ensureTexture()
                 GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, textureId)
-                GLUtils.texImage2D(GLES20.GL_TEXTURE_2D, 0, bitmap, 0)
+                if (srcWidth == bitmap.width && srcHeight == bitmap.height) {
+                    // 尺寸未变的重传（滚动限频约 100ms 一次）：子区域更新复用既有
+                    // 分配，不再整张重分配 1080p 级纹理（约 10MB/次）。首次上传
+                    // （srcWidth 还是 0）与尺寸变化走下面的 texImage2D。
+                    GLUtils.texSubImage2D(GLES20.GL_TEXTURE_2D, 0, 0, 0, bitmap)
+                } else {
+                    GLUtils.texImage2D(GLES20.GL_TEXTURE_2D, 0, bitmap, 0)
+                }
                 val e = GLES20.glGetError()
                 if (e != GLES20.GL_NO_ERROR) {
-                    fail("texImage2D", RuntimeException("glError=$e"))
+                    fail("uploadSource glError=$e", null)
                     return@post
                 }
                 srcWidth = bitmap.width
@@ -158,11 +165,22 @@ internal class GlassLensSource {
         )
     }
 
-    private fun fail(where: String, t: Throwable) {
+    private fun fail(where: String, t: Throwable?) {
         if (!ownFailed) {
             ownFailed = true
             android.util.Log.w("GlassLensSource", "disabled at $where", t)
         }
+    }
+
+    /**
+     * 底图捕获失败（锚点快照拿不到）：走 snapshot 失败传播。
+     *
+     * `rememberGlassLensAnchor` 读到 [failed] 后收回锚点，站点重组切回 blur
+     * 兜底 —— 与 GL 失败同一条路。曾经捕获失败只 latch 在锚点里的一个普通
+     * Boolean 上，组合期读不到，元素从此永久空白。
+     */
+    internal fun failCapture() {
+        fail("capture", null)
     }
 }
 

--- a/docs/glass-lens-api32.md
+++ b/docs/glass-lens-api32.md
@@ -78,9 +78,9 @@ if (!isRuntimeShaderSupported()) return   // Lens.kt:22
 行数是快照，改代码时容易忘了同步（已经飘过一次）。以 `wc -l` 为准，别照着这里的数字下结论。
 
 仪器测试在 `app/src/androidTest/.../glass/`：`GlassLensRendererTest` 验上线代码真的出
-折射（含区域共享语义，6 个用例）；另三个是探路阶段的证据，分别记录
-`Bitmap.createBitmap(Picture)` 可用、ES 2.0 离屏可跑复杂着色器、以及零回读通路
-**更慢所以放弃**。
+折射（含区域共享语义、同尺寸重传、静止态饱和度不变式，7 个用例）；另三个是探路
+阶段的证据，分别记录 `Bitmap.createBitmap(Picture)` 可用、ES 2.0 离屏可跑复杂
+着色器、以及零回读通路**更慢所以放弃**。
 
 这部分是本项目原创，因为库根本不需要它：AGSL 由平台喂输入、由平台合成输出，
 不存在「上下文」「底图」「重拍」这些概念。
@@ -237,8 +237,25 @@ GL/引擎级与底图捕获失败用 snapshot state 存（`failed` 触发重组�
 ## 9. 已知未完成
 
 - API 31 没有真机验证过（只有 32 和 35）。
-- 底栏指示器亮度比按算法预测值低约 6%（预测 222.7，实测 213）；
-  疑点在底图重建与库自己的 `vibrancy()` 之间，以及着色器里 `vibrancy = 1.28`。
+- 底栏指示器亮度比按算法预测值低约 6%（预测 222.7，实测 213）。**已排除着色器
+  这一侧**，别再去调光学参数：
+
+  | 假设 | 结论 | 依据 |
+  | --- | --- | --- |
+  | 库 `vibrancy()` 与着色器 1.28 叠了两遍 | 排除 | 31/32 上 `onDrawBackdrop` 不调 `drawBackdrop()`（`CapsuleNavigationBar.kt:929`），库那条 effects 链一个像素都没画，vibrancy 只有着色器这一份 |
+  | 着色器公式与预测脚本不同式 | 排除 | 短路分支就是 `applyVibrancy(texture2D(...), 1.28)`，与 `cmp.py` 的 `vib()` 逐项相同 |
+  | 元素浮点窗口坐标 → GL_LINEAR 混邻纹素 | 排除 | 拿真实底图 dump 算过：偏差 0.01%。底图是 blur 过的，局部近似线性，双线性≈精确 |
+  | 混色/预乘 alpha | 排除 | 从未 `glEnable(GL_BLEND)`；SDF 是硬截断，alpha 只有 0 或 1 |
+  | 表面 tint 压暗 | 方向不对 | 亮主题是白 @0.34（`NavSelectedSolidAlpha`），只会更亮 |
+
+  并且 `restPathIsExactlyVibrancyOfSource` 用例已在 API 32 真机上把这条不变式钉住：
+  静止态输出**逐通道**等于 `setSaturation(1.28)` 作用在底图同点，容差 2/255。
+  6% 约合 15/255，真在这一侧的话该用例会大幅报红。
+
+  所以剩下的疑点只在**测量侧**：对比用的底图 dump 是否与出图那一帧同源（这个坑
+  已经栽过一次，见下面「探针 dump 是首帧」那类问题），以及「实测 213」是否读的
+  是合成后的截图（tint + highlight + innerShadow 之后）而非着色器原始输出 ——
+  那本就是两个不同的量。要收口需要重新在设备上量一轮，不是再读一遍代码。
 - ~~开关滑块仍是内联 `lens()` + 硬编码 5dp/10dp，没走 `resolvePhysicalLens`。~~
   **已解决**（圆钮类控件的真折射，见上面 8 节的覆盖表）。这一条曾经把文件写成
   `LiquidSelectionComponents.kt` —— 那是错的，该文件三处 `lens()` 一直都走

--- a/docs/glass-lens-api32.md
+++ b/docs/glass-lens-api32.md
@@ -67,17 +67,20 @@ if (!isRuntimeShaderSupported()) return   // Lens.kt:22
 
 | 文件 | 行数 | 做什么 |
 | --- | --- | --- |
-| `GlassLensEngine.kt` | 190 | 进程级共享 EGL 上下文 / GL 线程 / program 编译 / uniform location 缓存 / 失败一次即整体停用 |
-| `GlassLensRenderer.kt` | 433 | `GlassLensSource`（底图纹理，按区域共享）+ `GlassLensTarget`（FBO、回读缓冲、输出位图，按元素独占） |
-| `GlassLens.kt` | 671 | `GlassLensAnchor` 锚点、`Modifier.glassLens` / `Modifier.glassLensAnchor`、Backdrop→Picture→Bitmap 快照、上一帧结果的绘制与本帧提交 |
+| `GlassLensEngine.kt` | 185 | 进程级共享 EGL 上下文 / GL 线程 / program 编译 / uniform location 缓存 / 失败一次即整体停用 |
+| `GlassLensRenderer.kt` | 448 | `GlassLensSource`（底图纹理，按区域共享；尺寸未变的重传走 `texSubImage2D`）+ `GlassLensTarget`（FBO、回读缓冲、输出位图，按元素独占） |
+| `GlassLens.kt` | 879 | `GlassLensAnchor` 锚点、`Modifier.glassLens` / `Modifier.glassLensAnchor`、Backdrop→Picture→Bitmap 快照、上一帧结果的绘制与本帧提交、首帧/失败兜底 |
 | `GlassLensRegion.kt` | 108 | 「区域」抽象 + 两个 CompositionLocal（普通/模态预模糊） |
 | `GlassLensFreshness.kt` | 59 | 底图何时重拍：滚动限频 + 停下补拍 |
 | `GlassLensShader.kt` | 228 | 上面那段移植的着色器 + 为什么每一行是这样的说明 |
+| `PhysicalLensSurface.kt` 的 `glassLensOpticsFrom` | — | 把同一份 dp 配方换算成着色器要的像素量，与 33+ 共用 `lensScales` 曲线 |
+
+行数是快照，改代码时容易忘了同步（已经飘过一次）。以 `wc -l` 为准，别照着这里的数字下结论。
 
 仪器测试在 `app/src/androidTest/.../glass/`：`GlassLensRendererTest` 验上线代码真的出
-折射（含区域共享语义）；另三个是探路阶段的证据，分别记录 `Bitmap.createBitmap(Picture)`
-可用、ES 2.0 离屏可跑复杂着色器、以及零回读通路**更慢所以放弃**。
-| `PhysicalLensSurface.kt` 的 `glassLensOpticsFrom` | — | 把同一份 dp 配方换算成着色器要的像素量，与 33+ 共用 `lensScales` 曲线 |
+折射（含区域共享语义，6 个用例）；另三个是探路阶段的证据，分别记录
+`Bitmap.createBitmap(Picture)` 可用、ES 2.0 离屏可跑复杂着色器、以及零回读通路
+**更慢所以放弃**。
 
 这部分是本项目原创，因为库根本不需要它：AGSL 由平台喂输入、由平台合成输出，
 不存在「上下文」「底图」「重拍」这些概念。
@@ -118,6 +121,33 @@ Modifier.glassLens.draw()   画**上一帧**的结果，同时提交本帧
 `LocalGlassLensAnchor` 读，滑动时只改采样窗口 `u_srcOrigin`。
 另外底图必须**比元素大**，否则边缘采样会被 CLAMP 成一圈涂抹。
 
+**首帧与失败都有兜底，元素永远不会整块空白。** 调用方的 `onDrawBackdrop` 在
+锚点非 null 时把背景绘制让给了折射，而折射帧是异步渲的（提交 → GL 线程 →
+`onFrameReady` → 重绘）—— 中间那一两帧、以及各种失败路径上，元素靠什么显示：
+
+- **首帧间隙**：锚点保留 capture 产物作兜底底图（它本来上传完就弃，保留引用
+  零额外采集成本）。还没渲出帧的元素直接画底图上自己那块：同一个（已按实测
+  尺寸夹取的）圆角裁剪 + `ColorMatrix.setSaturation(vibrancy)` 复现着色器的
+  `applyVibrancy`，只是没有位移与色散。任一元素画出首帧后兜底位图即丢弃
+  （只置 null 不 recycle——区域内其他元素可能还在画它，recycle 会
+  use-after-recycle）。已知接受的残余：兜底丢弃后**新出现**的元素（如开弹窗）
+  仍有 1 帧空白，有入场淡入遮掩。
+- **底图捕获失败**：走 `source.failCapture()` → snapshot `failed` →
+  `rememberGlassLensAnchor` 收回锚点 → 重组切回 blur 兜底，与 GL 失败同一条路。
+  曾经只 latch 在锚点里的普通 Boolean 上，组合期读不到，元素永久空白。
+- **元素级渲染失败**（如 FBO 建不起来）：不提前 return 了——画 stale
+  `latest`（冻结在最后一帧）或兜底位图，只是不再提交新帧。曾经 failed 检查
+  放在画 latest **之前**的 return，失败后一个像素都不画，直到元素重组。
+
+**内存画像**（1080p 级）：GPU 常驻 ≈ 底栏条 + 全屏锐利底图 +（懒拍，首次
+开弹窗才有）全屏模糊底图 + 成绩页区域 ≈ 25MB 级；CPU 侧 capture 产物上传后
+即弃（GC 瞬态），兜底位图在正常路径上只存在于「首拍完成 → 首帧渲出」窗口内
+（约一张全屏 ARGB，一至三帧）。模态底图是懒的，不是预烤的。
+
+一个例外：**元素级失败且从未渲出过帧**时 `onFrameDrawn()` 永不触发，兜底位图
+会一直持有到锚点离开组合。这是有意的代价 —— 它是那个元素唯一还看得见东西的
+原因 —— 但「稳态零额外内存」在这条路径上不成立，量内存时别把它当异常。
+
 ## 5. 底图要复现「元素实际压着的东西」
 
 AGSL 的输入由平台自动提供；GL 这边必须**手工重建同一张图**。这是整个移植里最容易错的地方。
@@ -147,6 +177,10 @@ AGSL 的输入由平台自动提供；GL 这边必须**手工重建同一张图*
 - 滚动期间 → 限频 100ms 一次（≈5% 开销）。
 - 滚动停下 / 换页动画结束 → 补拍一次（用户真正盯着看的是静止态）。
 - 静止 → 零开销。
+
+重传本身也分两档：尺寸未变（绝大多数情况）走 `texSubImage2D` 子区域更新，
+复用既有纹理分配；只有尺寸变化才 `texImage2D` 整张重分配。滚动限频期间
+不再每 100ms 造一次 10MB 级的 GPU 重分配。
 
 试过并放弃：常驻 `HardwareRenderer` + `SurfaceTexture` 的零回读通路。
 中位 4.69ms、p90 15.99ms，比现在**更差** —— `HardwareRenderer` 按 vsync 节拍走，
@@ -193,16 +227,27 @@ fun isGlassLensApplicable(): Boolean   // 只在 31/32 为 true
 
 **一个雷**：走折射路径时调用方的 `onDrawBackdrop` 会**让掉**正常的背景绘制
 （背景由折射负责画）。所以折射一旦失效而组合期读不到这个变化，元素就永远没有背景 ——
-屏幕上是整块面板消失（弹窗上实拍到过）。因此 `failed` 用 snapshot state 存，
-失败会触发重组、连 blur 兜底一起切回去；锚点没挂到节点上时 `warnUnanchored()` 会报错。
+屏幕上是整块面板消失（弹窗上实拍到过）。因此三级失败全部要能被组合期或绘制期读到：
+GL/引擎级与底图捕获失败用 snapshot state 存（`failed` 触发重组、连 blur 兜底
+一起切回去）；元素级失败不在组合期能摸到的地方（target 在 Modifier.Node 里），
+就退化成「画 stale 最后一帧、不再提交」而不是空白。锚点没挂到节点上时
+`warnUnanchored()` 会报错（debug 构建升级为 `Log.wtf`，且 `rememberGlassLensAnchor`
+等两帧后组合期主动自检一次，不再依赖区域内恰好有元素在 draw）。
 
 ## 9. 已知未完成
 
 - API 31 没有真机验证过（只有 32 和 35）。
 - 底栏指示器亮度比按算法预测值低约 6%（预测 222.7，实测 213）；
   疑点在底图重建与库自己的 `vibrancy()` 之间，以及着色器里 `vibrancy = 1.28`。
-- 开关滑块（`LiquidSelectionComponents.kt`）仍是内联 `lens()` + 硬编码 5dp/10dp，
-  没走 `resolvePhysicalLens`。
+- ~~开关滑块仍是内联 `lens()` + 硬编码 5dp/10dp，没走 `resolvePhysicalLens`。~~
+  **已解决**（圆钮类控件的真折射，见上面 8 节的覆盖表）。这一条曾经把文件写成
+  `LiquidSelectionComponents.kt` —— 那是错的，该文件三处 `lens()` 一直都走
+  `resolvePhysicalLens`。真正硬编码的是 `LiquidComponents.kt`（开关旋钮）、
+  `LiquidColorField.kt`（色板摘钮）、`GlassGradientSlider.kt`（滑块 thumb），
+  而三处**都在 `if (switchLensAnchor == null)` 里**，即 API ≤ 30 的 legacy 兜底；
+  31/32 上折射已由 `glassLens` + `ThumbLens.kt` 的 `thumbLensOptics` 接管。
+  那几个 dp 数字照库 catalog 的 LiquidSlider 抄，是刻意保留的，见
+  `ThumbLens.kt` 的类注释。
 - 真机上的实际帧开销还没量（探针已随本版删除，量的时候要重新加回临时插桩）。
 
 ## 10. 参考


### PR DESCRIPTION
API 31/32 没有 AGSL，折射走自研的离屏 OpenGL ES 2.0 路径。调用方在锚点非 null 时会把背景绘制**让给**折射（`onDrawBackdrop` 里 `if (lensAnchor == null) drawBackdrop()`），所以折射一旦不画，元素就是整块空白 —— 而不是退化成没有折射的样子。这个 PR 堵住三条会导致空白的路径，并修掉一个用户报告的开关旋钮问题。

API 33+ 零行为变化：所有改动都在 `isGlassLensApplicable()` 门内，33+ 上 `glassLens` 修饰符返回原 Modifier、节点不存在。

## 三条兜底

**首帧间隙。** 折射帧是异步渲的（提交 → GL 线程 → `onFrameReady` → 重绘），中间一两帧元素没有背景。现在锚点保留 capture 产物作兜底底图（它本来上传完就弃，保留引用零额外采集成本），还没渲出帧的元素直接画底图上自己那块 —— 同一个按实测尺寸夹取过的圆角裁剪 + `ColorMatrix.setSaturation` 复现着色器的 `applyVibrancy`。任一元素画出首帧即丢弃，正常路径稳态不占内存。App 冷启动的底栏是唯一没有入场淡入遮掩的场景，肉眼可见。

**底图捕获失败。** 改走 `source.failCapture()` → snapshot `failed` → `rememberGlassLensAnchor` 收回锚点 → 重组切回 blur 兜底，与 GL 失败同一条路。此前捕获失败只 latch 在锚点里一个普通 Boolean 上，组合期读不到，元素从此永久空白。

**元素级渲染失败。** `renderer.failed` 的检查从画 `latest` **之前**的提前 return 挪到之后，改为画 stale `latest`（冻结在最后一帧）或兜底位图，只是不再提交新帧。此前失败后一个像素都不画，持久元素（如底栏）要到重启才恢复。

## 开关旋钮按压态消失

用户报「按住开关旋钮就没了」。两台设备同页同控件逐像素对比（都是 1080x2400 @420dpi，开关都在 x817-984）：

- API 35（33+ 真 AGSL）按压中，旋钮上下各有一条**环境色**带 —— y1750-1765(16px) 与 y1820-1837(18px)，值约 `(149,128,181)` 淡紫，即壁纸被折射进来
- API 32（本路径）同一时刻旋钮内部**一条带都没有**，整块 `(52,199,89)` 纯轨道绿

根因：33+ 的轨道缩放是动画 `scaleY = lerp(0f, 0.75f, progress)`，而 31/32 的底图只能烤一个固定值，此前烤的是按满那一档 0.75。几何上，斜坡宽 5dp = 13.1px、旋钮半高 31.5px，要让斜坡整条采到轨道外面，缩后轨道半高必须 ≤ 18.4px（即 scaleY ≤ 0.50）；烤 0.75 时只探出 3.9px，那一点环境色被斜坡里的绿稀释掉，屏幕上就是纯绿。

改成 `scaleY = 0.4`（探出 16.8px，与 API 35 目测的 16/18px 带宽对得上），提为具名常量 `SWITCH_LENS_TRACK_SCALE_Y` 并把推导写进注释。`scaleX` 保持 0.75 —— 横向旋钮半宽本来就在缩后轨道半宽以内，两条路都没有横向带，设计如此。

原注释称「中途那一两百毫秒差异被自己盖住」，上面的对比就是反例，已一并更正。

## 其余

- 底图重传尺寸未变时走 `GLUtils.texSubImage2D`，不再每 100ms 重分配 1080p 级纹理（滚动限频期约 10MB/次）
- debug 构建加组合期锚点自检（等两帧），不再依赖区域内恰好有元素在 draw；draw 期报错去抖到第 3 次，避免 `SideEffect` 绕帧挂锚的分段控件首帧误报
- `drawFallback` 的圆角改按元素完整轮廓构造。此前半径乘了可见比例，元素被底图边界裁一半时会得到半圆角 —— 圆角是形状的属性，不是「可见了多少」的属性
- 删掉零引用且与注释不符的 `GlassLensEngine.resetForTest`
- 文档：兜底机制、失败传播三级、准确内存画像（含元素级失败下兜底常驻这个例外）；修回被改错的行数表；第 9 节划掉已由圆钮真折射解决的遗留项，并记录 6% 亮度差已排除着色器侧

## 新增测试

`reUploadSameSizeUpdatesOutput` —— 覆盖同尺寸版本号重传（滚动限频期每 100ms 都是这条路，被短路或写错位置会导致折射永远停在第一张底图上）。

`restPathIsExactlyVibrancyOfSource` —— 把静止态不变式钉住：输出逐通道等于 `setSaturation(1.28)` 作用在底图同点，容差 2/255。这条顺带结掉了文档第 9 节记的「底栏指示器亮度比预测低约 6%」：6% 约合 15/255，真在着色器侧的话该用例会大幅报红。配合另外几项排除（33+ 上 `drawBackdrop` 不被调用故 vibrancy 只有一份；双线性采样在 blur 过的底图上实测偏差 0.01%；从未 `glEnable(GL_BLEND)` 且 alpha 只有 0/1），结论是那 6% 不在着色器/采样/回读这一侧，疑点只剩测量侧。

## 验证

- `:app:testDebugUnitTest` —— 17 个测试类 0 失败（1 skip 是 `TyustSsoLiveTest`，需要真实网络）
- `:app:assembleDebug` —— 通过
- `:app:connectedDebugAndroidTest` —— API 32 真机 7 个用例全绿，含两个新增用例

## 审阅者需要知道的

**开关旋钮那条我没能在设备上目视复验** —— 重装 APK 后模拟器掉了登录态，设置页进不去。该改动的推导基于上面 API 35 的实测带宽，编译与全套测试通过，但「按住开关能看见旋钮」这个最终观感还没被人眼确认过。合并前建议实机按一下。

`scaleY = 0.4` 是按 @420dpi 推的。其它密度下比例关系不变（都是 dp 换算），但如果发现某密度下带宽不合适，调这一个常量即可，推导在注释里。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
